### PR TITLE
Add Claude provider and AI invoke command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "a-la-carte",
       "version": "0.0.1",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.54.0",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
-        "commander": "^14.0.0"
+        "commander": "^14.0.0",
+        "openai": "^5.3.0"
       },
       "bin": {
         "a": "dist/index.js"
@@ -47,6 +49,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz",
+      "integrity": "sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2058,6 +2069,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "vitest": "^1.3.2"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.54.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "openai": "^5.3.0"
   }
 }

--- a/src/commands/ai/invoke.ts
+++ b/src/commands/ai/invoke.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import Anthropic from "@anthropic-ai/sdk";
+import chalk from "chalk";
+import type { Command } from "commander";
+import OpenAI from "openai";
+import type { CommandRegistration } from "../../types";
+import { Config } from "../../utils/state";
+
+export class AiInvokeCommand implements CommandRegistration {
+    name = "invoke";
+    description = "Invoke the default AI provider with the contents of a file";
+
+    register(program: Command): void {
+        program
+            .command(this.name)
+            .description(this.description)
+            .argument("<path>", "File path containing the prompt")
+            .action(async (path) => {
+                await this.invoke(path);
+            });
+    }
+
+    private async invoke(path: string): Promise<void> {
+        const provider = Config.loadKey<string>("default-provider", "openai");
+        const content = readFileSync(path, "utf-8");
+        if (provider === "openai") {
+            const key = Config.loadKey<string>("openai-api-key");
+            const openai = new OpenAI({ apiKey: key });
+            const completion = await openai.chat.completions.create({
+                model: "gpt-3.5-turbo",
+                messages: [{ role: "user", content }],
+            });
+            const message = completion.choices[0]?.message?.content ?? "";
+            console.log(message.trim());
+        } else if (provider === "claude") {
+            const key = Config.loadKey<string>("claude-api-key");
+            const client = new Anthropic({ apiKey: key });
+            const message = await client.messages.create({
+                max_tokens: 1024,
+                messages: [{ role: "user", content }],
+                model: "claude-3-5-sonnet-latest",
+            });
+            const text = Array.isArray(message.content)
+                ? message.content.map((c) => (typeof c === "string" ? c : c.text)).join("\n")
+                : String(message.content);
+            console.log(text.trim());
+        } else {
+            console.log(chalk.red(`Unknown provider: ${provider}`));
+        }
+    }
+}

--- a/src/commands/ai/set-claude-key.ts
+++ b/src/commands/ai/set-claude-key.ts
@@ -1,0 +1,26 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import type { CommandRegistration } from "../../types";
+import { Config } from "../../utils/state";
+
+export class AiSetClaudeKeyCommand implements CommandRegistration {
+    name = "set-claude-key";
+    description = "Sets the Anthropic Claude API key for use with AI commands";
+
+    register(program: Command): void {
+        program
+            .command(this.name)
+            .description(this.description)
+            .argument("<key>", "The Anthropic Claude API key to store")
+            .action(async (key) => {
+                await this.setClaudeKey(key);
+            });
+    }
+
+    private async setClaudeKey(key: string): Promise<void> {
+        Config.setKey("claude-api-key", key);
+        console.log(
+            chalk.green(`Successfully set Claude API key (${chalk.whiteBright(`${key.substring(0, 14)}...`)})`)
+        );
+    }
+}

--- a/src/commands/ai/set-default-provider.ts
+++ b/src/commands/ai/set-default-provider.ts
@@ -1,0 +1,29 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import type { CommandRegistration } from "../../types";
+import { Config } from "../../utils/state";
+
+export class AiSetDefaultProviderCommand implements CommandRegistration {
+    name = "set-default-provider";
+    description = "Sets the default AI provider (openai or claude)";
+
+    register(program: Command): void {
+        program
+            .command(this.name)
+            .description(this.description)
+            .argument("<provider>", "Provider to use: openai or claude")
+            .action(async (provider) => {
+                await this.setProvider(provider);
+            });
+    }
+
+    private async setProvider(provider: string): Promise<void> {
+        const normalized = provider.toLowerCase();
+        if (normalized !== "openai" && normalized !== "claude") {
+            console.log(chalk.red("Provider must be 'openai' or 'claude'"));
+            process.exit(1);
+        }
+        Config.setKey("default-provider", normalized);
+        console.log(chalk.green(`Default provider set to ${chalk.whiteBright(normalized)}`));
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@
 import { Command } from "commander";
 import { AskClaudeCommand } from "./commands/ai/ask-claude";
 import { AskCodexCommand } from "./commands/ai/ask-codex";
+import { AiInvokeCommand } from "./commands/ai/invoke";
+import { AiSetClaudeKeyCommand } from "./commands/ai/set-claude-key";
+import { AiSetDefaultProviderCommand } from "./commands/ai/set-default-provider";
 import { AiSetOpenAiKeyCommand } from "./commands/ai/set-openai-key";
 import { CodePopCommand } from "./commands/code/pop";
 import { CodeRebasePrsCommand } from "./commands/code/rebase-prs";
@@ -39,6 +42,9 @@ function main() {
     new AskClaudeCommand().register(ai);
     new AskCodexCommand().register(ai);
     new AiSetOpenAiKeyCommand().register(ai);
+    new AiSetClaudeKeyCommand().register(ai);
+    new AiSetDefaultProviderCommand().register(ai);
+    new AiInvokeCommand().register(ai);
 
     program.parse();
 }


### PR DESCRIPTION
## Summary
- support storing Anthropic Claude API keys
- allow setting a default AI provider
- implement `invoke` command to call the default provider
- register new commands
- include OpenAI and Anthropic SDK dependencies

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684f00d862d88320862b7912598d5996