### PR TITLE
Refactor command registration

### DIFF
--- a/src/commands/ai/ask-claude.ts
+++ b/src/commands/ai/ask-claude.ts
@@ -1,13 +1,13 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bashInNewTerminal } from "../../utils/bash";
 import { cloneFreshRepo } from "../../utils/clone-repo";
 import { combinePromptsWithMessage, loadPrompts } from "../../utils/prompts";
 import { Config } from "../../utils/state";
 
-function collectPrompts(value: string, previous: string[]): string[] {
-    return previous.concat([value]);
+export interface AskClaudeArgs {
+    message: string;
+    prompt: string[];
+    delegate: boolean;
 }
 
 async function getClaudeKey(): Promise<string> {
@@ -51,21 +51,7 @@ async function ask(message: string, promptNames: string[], delegate: boolean): P
     }
 }
 
-export const registerAskClaudeCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("claude")
-        .description(
-            "Ask Claude to help with a request. By default, claude will work in the current workspace. Use --delegate to have claude work in a fresh cloned repository."
-        )
-        .option(
-            "-p, --prompt <name>",
-            "Load a prompt from the config system (can be used multiple times)",
-            collectPrompts,
-            []
-        )
-        .option("-d, --delegate", "Clone the current repository and have claude work in a separate workspace")
-        .argument("<message>", "The message to ask claude")
-        .action(async (message: string, options: { prompt: string[]; delegate?: boolean }) => {
-            await ask(message, options.prompt, options.delegate || false);
-        });
-};
+export async function askClaude(args: AskClaudeArgs): Promise<void> {
+    const { message, prompt, delegate } = args;
+    await ask(message, prompt, delegate);
+}

--- a/src/commands/ai/ask-codex.ts
+++ b/src/commands/ai/ask-codex.ts
@@ -1,13 +1,13 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bashInNewTerminal } from "../../utils/bash";
 import { cloneFreshRepo } from "../../utils/clone-repo";
 import { combinePromptsWithMessage, loadPrompts } from "../../utils/prompts";
 import { Config } from "../../utils/state";
 
-function collectPrompts(value: string, previous: string[]): string[] {
-    return previous.concat([value]);
+export interface AskCodexArgs {
+    message: string;
+    prompt: string[];
+    delegate: boolean;
 }
 
 async function getOpenAiKey(): Promise<string> {
@@ -51,21 +51,7 @@ async function ask(message: string, promptNames: string[], delegate: boolean): P
     }
 }
 
-export const registerAskCodexCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("codex")
-        .description(
-            "Ask OpenAI Codex to help with a request. By default, codex will work in the current workspace. Use --delegate to have codex work in a fresh cloned repository."
-        )
-        .option(
-            "-p, --prompt <name>",
-            "Load a prompt from the config system (can be used multiple times)",
-            collectPrompts,
-            []
-        )
-        .option("-d, --delegate", "Clone the current repository and have codex work in a separate workspace")
-        .argument("<message>", "The message to ask codex")
-        .action(async (message: string, options: { prompt: string[]; delegate?: boolean }) => {
-            await ask(message, options.prompt, options.delegate || false);
-        });
-};
+export async function askCodex(args: AskCodexArgs): Promise<void> {
+    const { message, prompt, delegate } = args;
+    await ask(message, prompt, delegate);
+}

--- a/src/commands/ai/invoke.ts
+++ b/src/commands/ai/invoke.ts
@@ -1,10 +1,13 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
 import { combinePromptsWithMessage, loadPrompts } from "../../utils/prompts";
+
+export interface InvokeArgs {
+    message: string;
+    prompt: string[];
+}
 
 function collectPrompts(value: string, previous: string[]): string[] {
     return previous.concat([value]);
@@ -37,18 +40,7 @@ async function invoke(message: string, promptNames: string[]): Promise<void> {
     }
 }
 
-export const registerInvokeCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("invoke")
-        .description("Invoke your AI assistant using a custom script")
-        .option(
-            "-p, --prompt <name>",
-            "Load a prompt from the config system (can be used multiple times)",
-            collectPrompts,
-            []
-        )
-        .argument("<message>", "The message to send to your AI assistant")
-        .action(async (message: string, options: { prompt: string[] }) => {
-            await invoke(message, options.prompt);
-        });
-};
+export async function invokeAi(args: InvokeArgs): Promise<void> {
+    const { message, prompt } = args;
+    await invoke(message, prompt);
+}

--- a/src/commands/ai/set-claude-key.ts
+++ b/src/commands/ai/set-claude-key.ts
@@ -1,15 +1,11 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { Config } from "../../utils/state";
 
-export const registerSetClaudeKeyCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("set-claude-key")
-        .description("Set your Claude API key")
-        .argument("<key>", "Your Claude API key")
-        .action(async (key: string) => {
-            Config.setKey("claude-api-key", key);
-            console.log(chalk.green("Claude API key saved successfully!"));
-        });
-};
+export interface SetClaudeKeyArgs {
+    key: string;
+}
+
+export async function setClaudeKey(args: SetClaudeKeyArgs): Promise<void> {
+    Config.setKey("claude-api-key", args.key);
+    console.log(chalk.green("Claude API key saved successfully!"));
+}

--- a/src/commands/ai/set-default-provider.ts
+++ b/src/commands/ai/set-default-provider.ts
@@ -1,20 +1,17 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { Config } from "../../utils/state";
 
-export const registerSetDefaultProviderCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("set-default-provider")
-        .description("Set your default AI provider (openai or claude)")
-        .argument("<provider>", "The AI provider to set as default (openai or claude)")
-        .action(async (provider: string) => {
-            if (provider !== "openai" && provider !== "claude") {
-                console.log(chalk.red("Error: Provider must be either 'openai' or 'claude'"));
-                return;
-            }
+export interface SetDefaultProviderArgs {
+    provider: string;
+}
 
-            Config.setKey("default-provider", provider);
-            console.log(chalk.green(`Default AI provider set to ${provider}!`));
-        });
-};
+export async function setDefaultProvider(args: SetDefaultProviderArgs): Promise<void> {
+    const { provider } = args;
+    if (provider !== "openai" && provider !== "claude") {
+        console.log(chalk.red("Error: Provider must be either 'openai' or 'claude'"));
+        return;
+    }
+
+    Config.setKey("default-provider", provider);
+    console.log(chalk.green(`Default AI provider set to ${provider}!`));
+}

--- a/src/commands/ai/set-openai-key.ts
+++ b/src/commands/ai/set-openai-key.ts
@@ -1,15 +1,11 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { Config } from "../../utils/state";
 
-export const registerSetOpenAiKeyCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("set-openai-key")
-        .description("Set your OpenAI API key")
-        .argument("<key>", "Your OpenAI API key")
-        .action(async (key: string) => {
-            Config.setKey("openai-api-key", key);
-            console.log(chalk.green("OpenAI API key saved successfully!"));
-        });
-};
+export interface SetOpenAiKeyArgs {
+    key: string;
+}
+
+export async function setOpenAiKey(args: SetOpenAiKeyArgs): Promise<void> {
+    Config.setKey("openai-api-key", args.key);
+    console.log(chalk.green("OpenAI API key saved successfully!"));
+}

--- a/src/commands/code/pop.ts
+++ b/src/commands/code/pop.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
+
+export interface PopArgs {}
 
 async function pop(): Promise<void> {
     try {
@@ -21,11 +21,6 @@ async function pop(): Promise<void> {
     }
 }
 
-export const registerPopCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("pop")
-        .description("Pop the latest git stash")
-        .action(async () => {
-            await pop();
-        });
-};
+export async function popStash(_: PopArgs): Promise<void> {
+    await pop();
+}

--- a/src/commands/code/populate-description.ts
+++ b/src/commands/code/populate-description.ts
@@ -1,8 +1,8 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
+
+export interface PopulateDescriptionArgs {}
 
 async function populateDescription(): Promise<void> {
     try {
@@ -34,11 +34,6 @@ async function populateDescription(): Promise<void> {
     }
 }
 
-export const registerPopulateDescriptionCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("populate-description")
-        .description("Automatically populate the package.json description field")
-        .action(async () => {
-            await populateDescription();
-        });
-};
+export async function populateDescriptionAction(_: PopulateDescriptionArgs): Promise<void> {
+    await populateDescription();
+}

--- a/src/commands/code/rebase-prs.ts
+++ b/src/commands/code/rebase-prs.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
+
+export interface RebasePrsArgs {}
 
 async function rebasePrs(): Promise<void> {
     try {
@@ -50,11 +50,6 @@ async function rebasePrs(): Promise<void> {
     }
 }
 
-export const registerRebasePrsCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("rebase-prs")
-        .description("Rebase all open pull requests against the main branch")
-        .action(async () => {
-            await rebasePrs();
-        });
-};
+export async function rebasePullRequests(_: RebasePrsArgs): Promise<void> {
+    await rebasePrs();
+}

--- a/src/commands/code/shove.ts
+++ b/src/commands/code/shove.ts
@@ -1,7 +1,9 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
+
+export interface ShoveArgs {
+    message: string;
+}
 
 async function shove(message: string): Promise<void> {
     await bash("git add -A");
@@ -25,12 +27,6 @@ async function shove(message: string): Promise<void> {
     console.log(log);
 }
 
-export const registerShoveCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("shove")
-        .description("Force pushes your local changes to the remote repository")
-        .argument("<message>", "The message to commit with")
-        .action(async (message: string) => {
-            await shove(message);
-        });
-};
+export async function shoveChanges(args: ShoveArgs): Promise<void> {
+    await shove(args.message);
+}

--- a/src/commands/code/watch.ts
+++ b/src/commands/code/watch.ts
@@ -1,54 +1,45 @@
 import chalk from "chalk";
 import chokidar from "chokidar";
-import type { Command } from "commander";
-import type { CommandRegistration } from "../../types";
 import { bash } from "../../utils/bash";
 
-export class CodeWatchCommand implements CommandRegistration {
-    name = "watch";
-    description = "Watches files matching a pattern and runs a command on change";
+export interface WatchArgs {
+    pattern: string;
+    command: string;
+}
 
-    register(program: Command): void {
-        program
-            .command(this.name)
-            .description(this.description)
-            .argument("<pattern>", "Glob pattern of files to watch")
-            .argument("<command>", "Command to run on file change")
-            .action(async (pattern: string, command: string) => {
-                await this.watch(pattern, command);
-            });
-    }
+async function watch(pattern: string, command: string): Promise<void> {
+    console.log(
+        chalk.green(
+            `Watching ${chalk.whiteBright(pattern)} for changes. Running '${chalk.whiteBright(
+                command
+            )}' on change with 1s debounce.`
+        )
+    );
 
-    private async watch(pattern: string, command: string): Promise<void> {
-        console.log(
-            chalk.green(
-                `Watching ${chalk.whiteBright(pattern)} for changes. Running '${chalk.whiteBright(
-                    command
-                )}' on change with 1s debounce.`
-            )
-        );
+    const watcher = chokidar.watch(pattern, { ignoreInitial: true });
+    let timer: NodeJS.Timeout | null = null;
 
-        const watcher = chokidar.watch(pattern, { ignoreInitial: true });
-        let timer: NodeJS.Timeout | null = null;
+    const runCommand = async () => {
+        try {
+            console.log(chalk.gray(`> ${command}`));
+            await bash(command);
+            console.log(chalk.green(`Finished: ${chalk.whiteBright(command)}`));
+        } catch (error) {
+            console.log(chalk.red(`Command failed: ${error}`));
+        }
+    };
 
-        const runCommand = async () => {
-            try {
-                console.log(chalk.gray(`> ${command}`));
-                await bash(command);
-                console.log(chalk.green(`Finished: ${chalk.whiteBright(command)}`));
-            } catch (error) {
-                console.log(chalk.red(`Command failed: ${error}`));
-            }
-        };
+    watcher.on("change", () => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(runCommand, 1000);
+    });
 
-        watcher.on("change", () => {
-            if (timer) {
-                clearTimeout(timer);
-            }
-            timer = setTimeout(runCommand, 1000);
-        });
+    // Keep the process alive by never resolving the promise
+    await new Promise(() => {});
+}
 
-        // Keep the process alive by never resolving the promise
-        await new Promise(() => {});
-    }
+export async function watchFiles(args: WatchArgs): Promise<void> {
+    await watch(args.pattern, args.command);
 }

--- a/src/commands/config/add-prompt.ts
+++ b/src/commands/config/add-prompt.ts
@@ -1,8 +1,11 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
+
+export interface AddPromptArgs {
+    name: string;
+    content: string;
+}
 
 async function addPrompt(name: string, content: string): Promise<void> {
     const homeDir = process.env.HOME || process.env.USERPROFILE || "/";
@@ -40,13 +43,6 @@ async function addPrompt(name: string, content: string): Promise<void> {
     console.log(chalk.gray(`File saved to: ${filePath}`));
 }
 
-export const registerAddPromptCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("add-prompt")
-        .description("Adds a new prompt with the specified name and content")
-        .argument("<name>", "The name of the prompt")
-        .argument("<content>", "The content/text of the prompt")
-        .action(async (name: string, content: string) => {
-            await addPrompt(name, content);
-        });
-};
+export async function addPromptCommand(args: AddPromptArgs): Promise<void> {
+    await addPrompt(args.name, args.content);
+}

--- a/src/commands/config/list-prompts.ts
+++ b/src/commands/config/list-prompts.ts
@@ -1,8 +1,8 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
+
+export interface ListPromptsArgs {}
 
 function listPrompts(): void {
     const homeDir = process.env.HOME || process.env.USERPROFILE || "/";
@@ -30,11 +30,6 @@ function listPrompts(): void {
     }
 }
 
-export const registerListPromptsCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("list-prompts")
-        .description("List all available prompts")
-        .action(() => {
-            listPrompts();
-        });
-};
+export async function listPromptsCommand(_: ListPromptsArgs): Promise<void> {
+    listPrompts();
+}

--- a/src/commands/config/open.ts
+++ b/src/commands/config/open.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { bash } from "../../utils/bash";
+
+export interface OpenConfigArgs {}
 
 async function openConfig(): Promise<void> {
     const homeDir = process.env.HOME || process.env.USERPROFILE || "/";
@@ -34,11 +34,6 @@ async function openConfig(): Promise<void> {
     }
 }
 
-export const registerOpenCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("open")
-        .description("Open the configuration file in your default editor")
-        .action(async () => {
-            await openConfig();
-        });
-};
+export async function openConfigCommand(_: OpenConfigArgs): Promise<void> {
+    await openConfig();
+}

--- a/src/commands/config/set-source.ts
+++ b/src/commands/config/set-source.ts
@@ -1,15 +1,11 @@
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { Config } from "../../utils/state";
 
-export const registerSetSourceCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("set-source")
-        .description("Set the source URL for configuration syncing")
-        .argument("<url>", "The git repository URL to sync configuration from")
-        .action(async (url: string) => {
-            Config.setKey("config-source", url);
-            console.log(chalk.green(`Configuration source set to: ${chalk.whiteBright(url)}`));
-        });
-};
+export interface SetSourceArgs {
+    url: string;
+}
+
+export async function setSource(args: SetSourceArgs): Promise<void> {
+    Config.setKey("config-source", args.url);
+    console.log(chalk.green(`Configuration source set to: ${chalk.whiteBright(args.url)}`));
+}

--- a/src/commands/config/sync.ts
+++ b/src/commands/config/sync.ts
@@ -2,9 +2,9 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { Command } from "commander";
-import type { CommandRegistrator } from "../../types";
 import { Config } from "../../utils/state";
+
+export interface SyncArgs {}
 
 async function sync(): Promise<void> {
     try {
@@ -42,11 +42,6 @@ async function sync(): Promise<void> {
     }
 }
 
-export const registerSyncCommand: CommandRegistrator = (program: Command): void => {
-    program
-        .command("sync")
-        .description("Sync configuration from a remote git repository")
-        .action(async () => {
-            await sync();
-        });
-};
+export async function syncConfig(_: SyncArgs): Promise<void> {
+    await sync();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-import { AskClaudeCommand } from "./commands/ai/ask-claude";
-import { AskCodexCommand } from "./commands/ai/ask-codex";
-import { AiInvokeCommand } from "./commands/ai/invoke";
-import { AiSetClaudeKeyCommand } from "./commands/ai/set-claude-key";
-import { AiSetDefaultProviderCommand } from "./commands/ai/set-default-provider";
-import { AiSetOpenAiKeyCommand } from "./commands/ai/set-openai-key";
-import { CodePopCommand } from "./commands/code/pop";
-import { CodePopulateDescriptionCommand } from "./commands/code/populate-description";
-import { CodeRebasePrsCommand } from "./commands/code/rebase-prs";
-import { CodeShoveCommand } from "./commands/code/shove";
-import { CodeWatchCommand } from "./commands/code/watch";
-import { ConfigAddPromptCommand } from "./commands/config/add-prompt";
-import { ConfigListPromptsCommand } from "./commands/config/list-prompts";
-import { ConfigOpenCommand } from "./commands/config/open";
-import { ConfigSetSourceCommand } from "./commands/config/set-source";
-import { ConfigSyncCommand } from "./commands/config/sync";
+import { askClaude, AskClaudeArgs } from "./commands/ai/ask-claude";
+import { askCodex, AskCodexArgs } from "./commands/ai/ask-codex";
+import { invokeAi, InvokeArgs } from "./commands/ai/invoke";
+import { setClaudeKey, SetClaudeKeyArgs } from "./commands/ai/set-claude-key";
+import { setDefaultProvider, SetDefaultProviderArgs } from "./commands/ai/set-default-provider";
+import { setOpenAiKey, SetOpenAiKeyArgs } from "./commands/ai/set-openai-key";
+import { popStash, PopArgs } from "./commands/code/pop";
+import { populateDescriptionAction, PopulateDescriptionArgs } from "./commands/code/populate-description";
+import { rebasePullRequests, RebasePrsArgs } from "./commands/code/rebase-prs";
+import { shoveChanges, ShoveArgs } from "./commands/code/shove";
+import { watchFiles, WatchArgs } from "./commands/code/watch";
+import { addPromptCommand, AddPromptArgs } from "./commands/config/add-prompt";
+import { listPromptsCommand, ListPromptsArgs } from "./commands/config/list-prompts";
+import { openConfigCommand, OpenConfigArgs } from "./commands/config/open";
+import { setSource, SetSourceArgs } from "./commands/config/set-source";
+import { syncConfig, SyncArgs } from "./commands/config/sync";
+
+function collectPrompts(value: string, previous: string[]): string[] {
+    return previous.concat([value]);
+}
 
 function main() {
     const program = new Command();
@@ -27,27 +31,161 @@ function main() {
     const config = program.command("config").description("Config rules and prompts management");
     const ai = program.command("ai").description("AI related utilities");
 
-    // Register subcommands under "code"
-    new CodeShoveCommand().register(code);
-    new CodePopCommand().register(code);
-    new CodePopulateDescriptionCommand().register(code);
-    new CodeRebasePrsCommand().register(code);
-    new CodeWatchCommand().register(code);
+    // code commands
+    code.command("shove")
+        .description("Force pushes your local changes to the remote repository")
+        .argument("<message>", "The message to commit with")
+        .action(async (message: string) => {
+            const args: ShoveArgs = { message };
+            await shoveChanges(args);
+        });
 
-    // Register subcommands under "config"
-    new ConfigSyncCommand().register(config);
-    new ConfigSetSourceCommand().register(config);
-    new ConfigAddPromptCommand().register(config);
-    new ConfigListPromptsCommand().register(config);
-    new ConfigOpenCommand().register(config);
+    code.command("pop")
+        .description("Pop the latest git stash")
+        .action(async () => {
+            const args: PopArgs = {};
+            await popStash(args);
+        });
 
-    // Register subcommands under "ai"
-    new AskClaudeCommand().register(ai);
-    new AskCodexCommand().register(ai);
-    new AiSetOpenAiKeyCommand().register(ai);
-    new AiSetClaudeKeyCommand().register(ai);
-    new AiSetDefaultProviderCommand().register(ai);
-    new AiInvokeCommand().register(ai);
+    code.command("populate-description")
+        .description("Automatically populate the package.json description field")
+        .action(async () => {
+            const args: PopulateDescriptionArgs = {};
+            await populateDescriptionAction(args);
+        });
+
+    code.command("rebase-prs")
+        .description("Rebase all open pull requests against the main branch")
+        .action(async () => {
+            const args: RebasePrsArgs = {};
+            await rebasePullRequests(args);
+        });
+
+    code.command("watch")
+        .description("Watches files matching a pattern and runs a command on change")
+        .argument("<pattern>", "Glob pattern of files to watch")
+        .argument("<command>", "Command to run on file change")
+        .action(async (pattern: string, commandStr: string) => {
+            const args: WatchArgs = { pattern, command: commandStr };
+            await watchFiles(args);
+        });
+
+    // config commands
+    config
+        .command("sync")
+        .description("Sync configuration from a remote git repository")
+        .action(async () => {
+            const args: SyncArgs = {};
+            await syncConfig(args);
+        });
+
+    config
+        .command("set-source")
+        .description("Set the source URL for configuration syncing")
+        .argument("<url>", "The git repository URL to sync configuration from")
+        .action(async (url: string) => {
+            const args: SetSourceArgs = { url };
+            await setSource(args);
+        });
+
+    config
+        .command("add-prompt")
+        .description("Adds a new prompt with the specified name and content")
+        .argument("<name>", "The name of the prompt")
+        .argument("<content>", "The content/text of the prompt")
+        .action(async (name: string, content: string) => {
+            const args: AddPromptArgs = { name, content };
+            await addPromptCommand(args);
+        });
+
+    config
+        .command("list-prompts")
+        .description("List all available prompts")
+        .action(async () => {
+            const args: ListPromptsArgs = {};
+            await listPromptsCommand(args);
+        });
+
+    config
+        .command("open")
+        .description("Open the configuration file in your default editor")
+        .action(async () => {
+            const args: OpenConfigArgs = {};
+            await openConfigCommand(args);
+        });
+
+    // ai commands
+    ai.command("claude")
+        .description(
+            "Ask Claude to help with a request. By default, claude will work in the current workspace. Use --delegate to have claude work in a fresh cloned repository."
+        )
+        .option(
+            "-p, --prompt <name>",
+            "Load a prompt from the config system (can be used multiple times)",
+            collectPrompts,
+            []
+        )
+        .option("-d, --delegate", "Clone the current repository and have claude work in a separate workspace")
+        .argument("<message>", "The message to ask claude")
+        .action(async (message: string, options: { prompt: string[]; delegate?: boolean }) => {
+            const args: AskClaudeArgs = { message, prompt: options.prompt, delegate: options.delegate ?? false };
+            await askClaude(args);
+        });
+
+    ai.command("codex")
+        .description(
+            "Ask OpenAI Codex to help with a request. By default, codex will work in the current workspace. Use --delegate to have codex work in a fresh cloned repository."
+        )
+        .option(
+            "-p, --prompt <name>",
+            "Load a prompt from the config system (can be used multiple times)",
+            collectPrompts,
+            []
+        )
+        .option("-d, --delegate", "Clone the current repository and have codex work in a separate workspace")
+        .argument("<message>", "The message to ask codex")
+        .action(async (message: string, options: { prompt: string[]; delegate?: boolean }) => {
+            const args: AskCodexArgs = { message, prompt: options.prompt, delegate: options.delegate ?? false };
+            await askCodex(args);
+        });
+
+    ai.command("invoke")
+        .description("Invoke your AI assistant using a custom script")
+        .option(
+            "-p, --prompt <name>",
+            "Load a prompt from the config system (can be used multiple times)",
+            collectPrompts,
+            []
+        )
+        .argument("<message>", "The message to send to your AI assistant")
+        .action(async (message: string, options: { prompt: string[] }) => {
+            const args: InvokeArgs = { message, prompt: options.prompt };
+            await invokeAi(args);
+        });
+
+    ai.command("set-openai-key")
+        .description("Set your OpenAI API key")
+        .argument("<key>", "Your OpenAI API key")
+        .action(async (key: string) => {
+            const args: SetOpenAiKeyArgs = { key };
+            await setOpenAiKey(args);
+        });
+
+    ai.command("set-claude-key")
+        .description("Set your Claude API key")
+        .argument("<key>", "Your Claude API key")
+        .action(async (key: string) => {
+            const args: SetClaudeKeyArgs = { key };
+            await setClaudeKey(args);
+        });
+
+    ai.command("set-default-provider")
+        .description("Set your default AI provider (openai or claude)")
+        .argument("<provider>", "The AI provider to set as default (openai or claude)")
+        .action(async (provider: string) => {
+            const args: SetDefaultProviderArgs = { provider };
+            await setDefaultProvider(args);
+        });
 
     program.parse();
 }


### PR DESCRIPTION
## Summary
- move CLI registration logic into `src/index.ts`
- convert command modules to export argument interfaces and action functions

## Testing
- `npm test --silent` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0c9d1bd48320bdb6bdfef8dd3273