### PR TITLE
improved deligation to claude code

### DIFF
--- a/prompts/fix-linting.md
+++ b/prompts/fix-linting.md
@@ -1,0 +1,2 @@
+In the current repo, run linting and then fix any errors that you see so it passes.
+Run the lintint command and fix them and run again until it passes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-
-import { type AskClaudeArgs, askClaude } from "./commands/ai/ask-claude";
+import { askClaudeAiHander } from "./commands/ai/ask-claude";
 import { type AskCodexArgs, askCodex } from "./commands/ai/ask-codex";
 import { describePrAiHandler } from "./commands/ai/describe-pr";
 import { invokeAiHandler } from "./commands/ai/invoke";
@@ -89,11 +88,14 @@ function main() {
             []
         )
         .option("-d, --delegate", "Clone the current repository and have claude work in a separate workspace")
-        .argument("<message>", "The message to ask claude")
-        .action(async (message: string, options: { prompt: string[]; delegate?: boolean }) => {
-            const args: AskClaudeArgs = { message, prompt: options.prompt, delegate: options.delegate ?? false };
-            await askClaude(args);
-        });
+        .argument("[message]", "The message to ask claude")
+        .action((message: string | undefined, options: { prompt: string[]; delegate?: boolean }) =>
+            askClaudeAiHander({
+                request: message,
+                prompts: options.prompt,
+                freshRepo: options.delegate,
+            })
+        );
 
     ai.command("codex")
         .description(

--- a/src/utils/clone-repo.ts
+++ b/src/utils/clone-repo.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
 import { bash } from "./bash";
+import { Log } from "./logger";
 
 export async function cloneFreshRepo(): Promise<string> {
     const commitHashRaw = await bash("git rev-parse HEAD");
@@ -9,7 +10,7 @@ export async function cloneFreshRepo(): Promise<string> {
     const repoUrlRaw = await bash("git remote get-url origin");
     const repoUrl = repoUrlRaw.trim();
 
-    console.log(`Your repo is ${chalk.green(repoUrl)} at ${chalk.whiteBright(commitHash)} . . .`);
+    Log.log(`Cloning repo ${chalk.whiteBright(repoUrl)} . . .`);
 
     const homeDir = process.env.HOME || process.env.USERPROFILE || "/";
     const randomId = Math.random().toString(36).substring(2, 15);


### PR DESCRIPTION
### Improved delegation to Claude CLI and streamlined interface

---

### Changes
- Refactored `ask-claude` command logic to simplify delegation to Claude's CLI with better process handling and reliability.
- Replaced custom API key code with direct calls to local `claude` CLI, removing unnecessary API key checks.
- Added clearer logging and improved output about prompt usage and workspace locations via unified logger.
- Adjusted `ask-claude` argument parsing: now uses `request`, `prompts`, and `freshRepo` args for clarity.
- Changed behavior so runs can be performed either in a fresh repo clone or the current workspace, with improved process spawning.
- Added `prompts/fix-linting.md` helper prompt to the repository.
- Minor improvements to `clone-repo.ts` for logging and clarity.