### PR TITLE
Add config sync-rules command for syncing cursor rules

### DIFF
--- a/src/commands/config/sync-rules.ts
+++ b/src/commands/config/sync-rules.ts
@@ -1,0 +1,69 @@
+import { readdirSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { join, extname } from "node:path";
+import { execSync } from "node:child_process";
+import chalk from "chalk";
+import { Log } from "../../utils/logger";
+
+export interface SyncRulesArgs {}
+
+export async function syncRulesConfigHandler(_: SyncRulesArgs): Promise<void> {
+    try {
+        Log.info("Syncing rules from prompts/rules to .cursor/rules");
+
+        // Find git workspace root
+        const gitRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf-8" }).trim();
+        Log.log(`Git workspace root: ${chalk.whiteBright(gitRoot)}`);
+
+        // Source directory (prompts/rules from current working directory)
+        const sourceDir = join(process.cwd(), "prompts", "rules");
+        Log.log(`Source directory: ${chalk.whiteBright(sourceDir)}`);
+
+        // Target directory (.cursor/rules in git root)
+        const targetDir = join(gitRoot, ".cursor", "rules");
+        Log.log(`Target directory: ${chalk.whiteBright(targetDir)}`);
+
+        // Create target directory if it doesn't exist
+        mkdirSync(targetDir, { recursive: true });
+
+        // Read all files from source directory
+        let files: string[];
+        try {
+            files = readdirSync(sourceDir);
+        } catch (_error) {
+            Log.error(`Cannot read source directory: ${sourceDir}`);
+            return;
+        }
+
+        // Filter for .mdc files
+        const ruleFiles = files.filter((file) => extname(file) === ".mdc");
+
+        if (ruleFiles.length === 0) {
+            Log.warning("No rule files (.mdc) found in prompts/rules");
+            return;
+        }
+
+        Log.log(`Found ${chalk.green(ruleFiles.length.toString())} rule files: ${chalk.cyan(ruleFiles.join(", "))}`);
+
+        // Copy each rule file
+        let copiedCount = 0;
+        for (const file of ruleFiles) {
+            try {
+                const sourcePath = join(sourceDir, file);
+                const targetPath = join(targetDir, file);
+                
+                const content = readFileSync(sourcePath, "utf-8");
+                writeFileSync(targetPath, content, "utf-8");
+                
+                Log.log(`✓ Copied ${chalk.green(file)}`);
+                copiedCount++;
+            } catch (error) {
+                Log.error(`✗ Failed to copy ${file}: ${error instanceof Error ? error.message : "Unknown error"}`);
+            }
+        }
+
+        Log.info(`Successfully synced ${chalk.green(copiedCount.toString())} rule files to ${chalk.whiteBright(targetDir)}`);
+        
+    } catch (error) {
+        Log.error(`Failed to sync rules: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { setClaudeKeyConfigHandler } from "./commands/config/set-claude-key";
 import { setDefaultProviderConfigHandler } from "./commands/config/set-default-provider";
 import { setOpenAiKeyConfigHandler } from "./commands/config/set-openai-key";
 import { showConfigHandler } from "./commands/config/show";
+import { syncRulesConfigHandler } from "./commands/config/sync-rules";
 
 function main() {
     const program = new Command();
@@ -70,6 +71,11 @@ function main() {
         .description("Set your default AI provider (openai or claude)")
         .argument("<provider>", "The AI provider to set as default (openai or claude)")
         .action((provider: string) => setDefaultProviderConfigHandler({ provider }));
+
+    config
+        .command("sync-rules")
+        .description("Sync all rules from prompts/rules folder to .cursor/rules in git workspace root")
+        .action(() => syncRulesConfigHandler({}));
 
     // ai commands
     ai.command("describe-pr")


### PR DESCRIPTION
## Summary
- Added new `config sync-rules` command that syncs rules from `prompts/rules/` to `.cursor/rules/` in the git workspace root
- Command automatically detects git workspace root and creates necessary directories
- Copies all `.mdc` files with detailed logging and error handling
- Enables teams to maintain cursor rules in their project repository for consistent development experience

## Test plan
- [x] Build project successfully with `npm run build`
- [x] Test command execution with `node dist/index.js config sync-rules`
- [x] Verify files are copied correctly to `.cursor/rules/`
- [x] Run linting and address all issues
- [x] Test error handling for missing source directory

🤖 Generated with [Claude Code](https://claude.ai/code)