### PR TITLE
adding sync rules command

### DIFF
--- a/prompts/cut-pr.md
+++ b/prompts/cut-pr.md
@@ -1,1 +1,3 @@
 For the following request, please solve it and then open a github PR for me once you are confident that the solution is correct. Make sure to create a separate branch for the PR and credit yourself for the work in the pr description. When you create your branch, name the branch something like @ai/[todays date]/[2-3 word description of the request] like @ai/2025-06-13/add-a-new-feature
+
+github cli is a bit odd, so you should use this command for reference on creating the pr: gh pr create --base main --head NEWBRANCHNAME --title TITLE --body BODY

--- a/prompts/rules/code-style.mdc
+++ b/prompts/rules/code-style.mdc
@@ -1,0 +1,242 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Typescript Code Style
+
+When we are writing typescript projects, its important that we follow a clear structure and style guidance.
+Adhearance to this gives us better quality code in the long run. Since much of the code will be AI generated, sticking to these rules will help us maintain the codebase.
+
+The overarching principles we want to be aware of are:
+1. Class-first approach, without many (or any) global variables or global singletons. These patterns are hard to test and maintain.
+2. Interfaces are king. As systems get bigger, dedicated interfaces are the best way to define contracts between components. Use them sparingly but are pivitol in critial sections.
+3. Errors should never be generic. Throw them often, and make them specific. Custom error types allows error handling to be more effective and less flakey.
+4. Tests as specifications. Tests define how you want things to function, what behaviour you expect, and are the effective set of feature requirements of the system.
+
+## Class first approach
+
+We want to always jump for classes for constructing the system. This is critical to unlock solid testing.
+Classes should be conceptually structured like below:
+
+```ts
+
+import { Castle } from '../castles/castle';
+
+// Errors are defined in a separate file and are typed as a custom error type
+import { DragonError } from './errors';
+
+// Types are defined in a separate file and are used to type the parameters of the class
+// We want to avoid interfaces within classes and instead use a types file;
+import type { DragonParams } from './types';
+
+class Dragon {
+
+    private dragonName: string;
+    private residence: Castle;
+    private isDead: boolean;
+    private age: number;
+
+    constructor (params: DragonParams) {
+        this.dragonName = params.name;
+        this.residence = params.residence;
+        this.isDead = params.isDead ?? false;
+        this.age = params.age ?? 0;
+    }
+
+
+    // Private Utilities
+
+    private _properName () {
+        return `${this.dragonName} of ${this.residence.getName()}`
+    }
+
+    private _areOtherDragons () {
+        return this.residence.getDragons().length > 1;
+    }
+
+    // Public API
+
+    /**
+     * Changes the dragon's residence to a new castle
+     * @param newResidence - The castle to move to
+     * @throws DragonError if the new residence is the same as current
+     */
+    public changeResidence(newResidence: Castle): void {
+        if (newResidence === this.residence) {
+            throw new DragonError('Cannot move to same residence');
+        }
+        this.residence = newResidence;
+    }
+
+    /**
+     * Creates a new baby dragon with the given name
+     * @param babyName - Name for the new dragon
+     * @returns The newly created baby dragon
+     * @throws DragonError if the dragon is too young to have babies
+     */
+    public haveBaby(babyName: string): Dragon {
+        if (this.age < 100) {
+            throw new DragonError('Dragon must be at least 100 years old to have babies');
+        }
+        return new Dragon(babyName, this.residence);
+    }
+
+    /**
+     * Kills the dragon, removing it from its residence
+     * @throws DragonError if the dragon is already dead
+     */
+    public kill(): void {
+        if (this.isDead) {
+            throw new DragonError('Dragon is already dead');
+        }
+        this.isDead = true;
+        this.residence.removeDragon(this);
+    }
+
+}
+
+```
+
+
+## Interfaces are king
+
+Interfaces allow us to reason about the system more abstractly, then enforce that system is correct. 
+Interfaces in typescript are a specific type definition, but what we mean here is the concept of a defined contract between two sections of the system.
+
+```ts
+interface AttackAction {
+    
+    // The name of the attack
+    name: string;
+
+    // The power of the attack
+    power: number;
+
+    // The type of the attack
+    type: AttackType;
+    
+    // Handlers to handle the attack
+    applyAttack(target: Dragon): void;
+}
+```
+
+## Errors should never be generic
+
+Errors should be specific to the problem they are solving. This allows us to handle errors more effectively and less flakey.
+
+```ts
+
+// We can define a base error class that all other errors extend from which accepts a cause error for routing and tracing
+
+export class BaseError extends Error {
+    constructor(message: string, error?: Error) {
+        super(message, { cause: error });
+    }
+}
+
+// Simple extension of a base error class is sufficient for most cases
+
+export class DragonError extends BaseError {}
+export class DragonTooYoungError extends BaseError {}
+export class DragonAlreadyDeadError extends BaseError {}
+
+
+```
+
+Since we use errors this way, catch statements can be more specific and handle errors more effectively.
+
+```ts
+    try {
+        // ...
+    } catch (error) {
+        if (error instanceof DragonError) {
+            // ...
+        }
+        if (error instanceof DragonTooYoungError) {
+            // ...
+        }
+        if (error instanceof DragonAlreadyDeadError) {
+            // ...
+        }
+        // ...
+    }
+```
+
+## Tests as specifications
+
+When we write tests, there is a very specific structure we want to follow. Imagine first we have a natural language description of the behaviour of the system.
+That could look like this:
+
+```md
+
+### Dragons:
+- When we have a dragon which is in a residence 
+    - It can try to have a baby
+        - Success: The dragon will have a baby
+        - Failure: If the dragon is too young, it will throw a DragonTooYoungError
+        - Failure: If the dragon is already dead, it will throw a DragonAlreadyDeadError
+    - It can try to change its residence
+        - Success: The dragon will change its residence
+        - Failure: If the new residence is the same as the current residence, it will throw a DragonCannotMoveToSameResidenceError
+    - The dragon can be killed
+        - Success: The dragon will be killed
+        - Failure: If the dragon is already dead, it will throw a DragonAlreadyDeadError
+    - The dragon can be revived
+        - Success: The dragon will be revived
+        - Failure: If the dragon is not dead, it will throw a DragonNotDeadError
+- When we have a dragon which is not in a residence
+    - It can try to have a baby
+        - Failure: If the dragon is too young, it will throw a DragonTooYoungError
+        - Failure: If the dragon is already dead, it will throw a DragonAlreadyDeadError
+        - Failure: Since the dragon is not in a residence, it will throw a DragonNotInResidenceError
+    - It can try to change its residence
+        - Success: The dragon will change its residence
+
+```
+
+From this natural language description, we can write tests that are specific to the behaviour of the system. Every leaf node in the above tree should be a "test" expression and every non-leaf node should be a "describe" expression. Here is a partial mapping of the above to tests in vitest, notice how the classes and error types that we were careful to build all come together to form a complete test suite:
+
+```ts
+
+import { describe, test, expect } from 'vitest';
+
+describe('Dragons', () => {
+    describe('When we have a dragon which is in a residence', () => {
+        describe('It can try to have a baby', () => {
+            test('Success: The dragon will have a baby', () => {
+                const dragonInResidence = new Dragon({
+                    name: 'Dragon',
+                    residence: new Castle('Castle'),
+                    age: 100,
+                });
+
+                const babyDragon = dragonInResidence.haveBaby('Baby Dragon');
+
+                expect(babyDragon).toBeDefined();
+                expect(babyDragon.name).toBe('Baby Dragon');
+                expect(babyDragon.residence).toBe(dragonInResidence.residence);
+                expect(babyDragon.age).toBe(0);
+                expect(babyDragon.isDead).toBe(false);
+            });
+            test('Failure: If the dragon is too young, it will throw a DragonTooYoungError', () => {
+                const dragonInResidence = new Dragon({
+                    name: 'Dragon',
+                    residence: new Castle('Castle'),
+                    age: 99,
+                });
+                expect(() => dragonInResidence.haveBaby('Baby Dragon')).toThrow(DragonTooYoungError);
+            });
+            test('Failure: If the dragon is already dead, it will throw a DragonAlreadyDeadError', () => {
+                const dragonInResidence = new Dragon({
+                    name: 'Dragon',
+                    residence: new Castle('Castle'),
+                    isDead: true,
+                });
+                expect(() => dragonInResidence.haveBaby('Baby Dragon')).toThrow(DragonAlreadyDeadError);
+            });
+        });
+        
+    });
+});
+```

--- a/prompts/rules/prefered-stack.mdc
+++ b/prompts/rules/prefered-stack.mdc
@@ -1,0 +1,20 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Prefered Stack
+
+I am opinionated on what technology I want to use. When implementing something, always follow the current stack within the repo and dont migrate to others unless otherwise directed.
+If you are writing something new or do have an option to choose, then below are the preferend choices to make:
+
+```
+Language: Typescript
+UI: Nextjs
+Cloud: AWS
+Database: DynamoDB
+CI/CD: Github Actions
+Testing: Vitest
+Version Control: Git
+Linting: biomejs
+```

--- a/src/commands/config/sync-rules.ts
+++ b/src/commands/config/sync-rules.ts
@@ -1,0 +1,69 @@
+import { readdirSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { join, extname } from "node:path";
+import { execSync } from "node:child_process";
+import chalk from "chalk";
+import { Log } from "../../utils/logger";
+
+export interface SyncRulesArgs {}
+
+export async function syncRulesConfigHandler(_: SyncRulesArgs): Promise<void> {
+    try {
+        Log.info("Syncing rules from prompts/rules to .cursor/rules");
+
+        // Find git workspace root
+        const gitRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf-8" }).trim();
+        Log.log(`Git workspace root: ${chalk.whiteBright(gitRoot)}`);
+
+        // Source directory (prompts/rules from current working directory)
+        const sourceDir = join(process.cwd(), "prompts", "rules");
+        Log.log(`Source directory: ${chalk.whiteBright(sourceDir)}`);
+
+        // Target directory (.cursor/rules in git root)
+        const targetDir = join(gitRoot, ".cursor", "rules");
+        Log.log(`Target directory: ${chalk.whiteBright(targetDir)}`);
+
+        // Create target directory if it doesn't exist
+        mkdirSync(targetDir, { recursive: true });
+
+        // Read all files from source directory
+        let files: string[];
+        try {
+            files = readdirSync(sourceDir);
+        } catch (_error) {
+            Log.error(`Cannot read source directory: ${sourceDir}`);
+            return;
+        }
+
+        // Filter for .mdc files
+        const ruleFiles = files.filter((file) => extname(file) === ".mdc");
+
+        if (ruleFiles.length === 0) {
+            Log.warning("No rule files (.mdc) found in prompts/rules");
+            return;
+        }
+
+        Log.log(`Found ${chalk.green(ruleFiles.length.toString())} rule files: ${chalk.cyan(ruleFiles.join(", "))}`);
+
+        // Copy each rule file
+        let copiedCount = 0;
+        for (const file of ruleFiles) {
+            try {
+                const sourcePath = join(sourceDir, file);
+                const targetPath = join(targetDir, file);
+                
+                const content = readFileSync(sourcePath, "utf-8");
+                writeFileSync(targetPath, content, "utf-8");
+                
+                Log.log(`✓ Copied ${chalk.green(file)}`);
+                copiedCount++;
+            } catch (error) {
+                Log.error(`✗ Failed to copy ${file}: ${error instanceof Error ? error.message : "Unknown error"}`);
+            }
+        }
+
+        Log.info(`Successfully synced ${chalk.green(copiedCount.toString())} rule files to ${chalk.whiteBright(targetDir)}`);
+        
+    } catch (error) {
+        Log.error(`Failed to sync rules: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+}

--- a/src/commands/config/sync-rules.ts
+++ b/src/commands/config/sync-rules.ts
@@ -1,69 +1,46 @@
-import { readdirSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
-import { join, extname } from "node:path";
 import { execSync } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { extname, join } from "node:path";
 import chalk from "chalk";
 import { Log } from "../../utils/logger";
 
 export interface SyncRulesArgs {}
 
 export async function syncRulesConfigHandler(_: SyncRulesArgs): Promise<void> {
-    try {
-        Log.info("Syncing rules from prompts/rules to .cursor/rules");
+    Log.info("Syncing rules from prompts/rules to .cursor/rules");
 
-        // Find git workspace root
-        const gitRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf-8" }).trim();
-        Log.log(`Git workspace root: ${chalk.whiteBright(gitRoot)}`);
+    const gitRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf-8" }).trim();
+    Log.log(`Git workspace root: ${chalk.whiteBright(gitRoot)}`);
 
-        // Source directory (prompts/rules from current working directory)
-        const sourceDir = join(process.cwd(), "prompts", "rules");
-        Log.log(`Source directory: ${chalk.whiteBright(sourceDir)}`);
+    const sourceDir = join(process.cwd(), "prompts", "rules");
+    Log.log(`Source rules directory: ${chalk.whiteBright(sourceDir)}`);
 
-        // Target directory (.cursor/rules in git root)
-        const targetDir = join(gitRoot, ".cursor", "rules");
-        Log.log(`Target directory: ${chalk.whiteBright(targetDir)}`);
+    const targetDir = join(gitRoot, ".cursor", "rules");
+    mkdirSync(targetDir, { recursive: true });
 
-        // Create target directory if it doesn't exist
-        mkdirSync(targetDir, { recursive: true });
+    const ruleFiles = readdirSync(sourceDir).filter((file) => extname(file) === ".mdc");
 
-        // Read all files from source directory
-        let files: string[];
-        try {
-            files = readdirSync(sourceDir);
-        } catch (_error) {
-            Log.error(`Cannot read source directory: ${sourceDir}`);
-            return;
-        }
-
-        // Filter for .mdc files
-        const ruleFiles = files.filter((file) => extname(file) === ".mdc");
-
-        if (ruleFiles.length === 0) {
-            Log.warning("No rule files (.mdc) found in prompts/rules");
-            return;
-        }
-
-        Log.log(`Found ${chalk.green(ruleFiles.length.toString())} rule files: ${chalk.cyan(ruleFiles.join(", "))}`);
-
-        // Copy each rule file
-        let copiedCount = 0;
-        for (const file of ruleFiles) {
-            try {
-                const sourcePath = join(sourceDir, file);
-                const targetPath = join(targetDir, file);
-                
-                const content = readFileSync(sourcePath, "utf-8");
-                writeFileSync(targetPath, content, "utf-8");
-                
-                Log.log(`✓ Copied ${chalk.green(file)}`);
-                copiedCount++;
-            } catch (error) {
-                Log.error(`✗ Failed to copy ${file}: ${error instanceof Error ? error.message : "Unknown error"}`);
-            }
-        }
-
-        Log.info(`Successfully synced ${chalk.green(copiedCount.toString())} rule files to ${chalk.whiteBright(targetDir)}`);
-        
-    } catch (error) {
-        Log.error(`Failed to sync rules: ${error instanceof Error ? error.message : "Unknown error"}`);
+    if (ruleFiles.length === 0) {
+        Log.warning("No rule files (.mdc) found in prompts/rules");
+        return;
     }
+
+    Log.log(`Found ${chalk.whiteBright(ruleFiles.length.toString())} rule files: ${chalk.cyan(ruleFiles.join(", "))}`);
+
+    // Copy each rule file
+    let copiedCount = 0;
+    for (const file of ruleFiles) {
+        const sourcePath = join(sourceDir, file);
+        const targetPath = join(targetDir, file);
+
+        const content = readFileSync(sourcePath, "utf-8");
+        writeFileSync(targetPath, content, "utf-8");
+
+        Log.log(`Copied ${chalk.green(file)}`);
+        copiedCount++;
+    }
+
+    Log.success(
+        `Successfully synced ${chalk.green(copiedCount.toString())} rule files to ${chalk.whiteBright(targetDir)}`
+    );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { setClaudeKeyConfigHandler } from "./commands/config/set-claude-key";
 import { setDefaultProviderConfigHandler } from "./commands/config/set-default-provider";
 import { setOpenAiKeyConfigHandler } from "./commands/config/set-openai-key";
 import { showConfigHandler } from "./commands/config/show";
+import { syncRulesConfigHandler } from "./commands/config/sync-rules";
 
 function main() {
     const program = new Command();
@@ -70,6 +71,11 @@ function main() {
         .description("Set your default AI provider (openai or claude)")
         .argument("<provider>", "The AI provider to set as default (openai or claude)")
         .action((provider: string) => setDefaultProviderConfigHandler({ provider }));
+
+    config
+        .command("sync-rules")
+        .description("Sync all rules from prompts/rules folder to .cursor/rules in git workspace root")
+        .action(() => syncRulesConfigHandler({}));
 
     // ai commands
     ai.command("describe-pr")


### PR DESCRIPTION
### Add sync-rules command to sync prompt rules into .cursor/rules

---

### Changes
- Added a new `config sync-rules` command that copies `.mdc` rule files from `prompts/rules` to `.cursor/rules` in the git workspace root.
- Created `src/commands/config/sync-rules.ts` with logic for syncing and detailed logging.
- Updated `src/index.ts` to register the new command with the CLI.
- Added new prompt rules: `prompts/rules/code-style.mdc` and `prompts/rules/prefered-stack.mdc`.
- Updated `prompts/cut-pr.md` to include reference for using the GitHub CLI for PR creation.

No breaking changes or API modifications; this is an additive feature for workspace setup automation.